### PR TITLE
Update path of package chacha20poly1305

### DIFF
--- a/go_benchmarks.go
+++ b/go_benchmarks.go
@@ -13,7 +13,7 @@ import (
 	"crypto/sha256"
 	"flag"
 	"fmt"
-	"golang.org/x/crypto/chacha20poly1305"
+	"pkg.go.dev/golang.org/x/crypto/chacha20poly1305"
 	"html"
 	"io"
 	"io/ioutil"


### PR DESCRIPTION
The package `chacha20poly1305` is now redirected to `pkg.go.dev/golang.org/x/crypto/chacha20poly1305`