### PR TITLE
Install specific golang version

### DIFF
--- a/run_benchmarks.sh
+++ b/run_benchmarks.sh
@@ -11,9 +11,9 @@ echo $out
 nprocs=`cat /proc/cpuinfo | awk '/^processor/{print $3}' | wc -l`
 
 if [ -x /usr/bin/apt-get ] || [ -x /usr/bin/apt ]; then
-       sudo apt-get install -y build-essential bc golang
+       sudo apt-get install -y build-essential bc golang-1.15
 elif [ -x /usr/bin/rpm ] || [ -x /usr/bin/dnf ]; then
-       sudo dnf install -y golang
+       sudo dnf install -y golang-1.15
 elif [ -x /usr/bin/pacman ]; then
        sudo pacman --noconfirm -S go
 fi


### PR DESCRIPTION
When using go version higher than 1.15, we see the following errors:

go_benchmarks.go:16:2: no required module provides package golang.org/x/crypto/chacha20poly1305: go.mod file not found in current                  directory or any parent directory; see 'go help modules'

The reason is that golang/crypto has release version only upto 1.15. Even if we try to use a golang/crypto version higher than that (ex. [internal-branch.go1.17-vendor] when using say go 1.17) then we get the following error:

package command-line-arguments
        imports golang.org/x/crypto/chacha20poly1305
        golang/go/src/golang.org/x/crypto/chacha20poly1305/chacha20poly1305_generic.go:11:2: use of internal package vendor/golang.org/            x/crypto/internal/subtle not allowed

Ideally the issue is due to the way go.mod is defined and how the golang/crypto doesn't have released versions for versions higher than 1.15.

As an interim workaround, the cf_benchmark repository was last updated 2 years ago, so we found go-1.15 to be the most apt version to use because it also has the compatible golang/crypto - 1.15 release version.